### PR TITLE
feat: add no repo option for testing

### DIFF
--- a/src/components/SourceDropdown.tsx
+++ b/src/components/SourceDropdown.tsx
@@ -28,13 +28,14 @@ export function SourceDropdown({ onSelectionChange, value }: SourceDropdownProps
       value={value}
       onChange={onSelectionChange}
     >
+      <Form.Dropdown.Item value="NO_REPO" title="No Repository" />
       {sources && sources.length > 0 ? (
         sources.map((source) => (
           <Form.Dropdown.Item
             key={source.id}
             value={source.name} // Using resource name as the ID/value
             title={getSourceLabel(source)}
-            // icon={source.githubRepo ? "github-logo.png" : Icon.Globe} // Removed icon to avoid needing Icon import or asset for now
+          // icon={source.githubRepo ? "github-logo.png" : Icon.Globe} // Removed icon to avoid needing Icon import or asset for now
           />
         ))
       ) : (

--- a/src/launch-session.tsx
+++ b/src/launch-session.tsx
@@ -52,23 +52,27 @@ export default function Command(props: LaunchProps<{ launchContext?: LaunchConte
 
       try {
         let startingBranch = values.startingBranch;
+        let sourceContext = undefined;
 
-        if (!startingBranch) {
-          const selectedSource = sources?.find((s) => s.name === values.sourceId);
-          if (selectedSource?.githubRepo?.defaultBranch?.displayName) {
-            startingBranch = selectedSource.githubRepo.defaultBranch.displayName;
-          } else {
-            // Fallback to "main" if we can't find the source or its default branch
-            startingBranch = "main";
+        if (values.sourceId !== "NO_REPO") {
+          if (!startingBranch) {
+            const selectedSource = sources?.find((s) => s.name === values.sourceId);
+            // ... logic to find default branch
+            if (selectedSource?.githubRepo?.defaultBranch?.displayName) {
+              startingBranch = selectedSource.githubRepo.defaultBranch.displayName;
+            } else {
+              startingBranch = "main";
+            }
           }
+          sourceContext = {
+            source: values.sourceId,
+            githubRepoContext: { startingBranch },
+          };
         }
 
         const response = await createSession({
           prompt: values.prompt,
-          sourceContext: {
-            source: values.sourceId,
-            githubRepoContext: { startingBranch },
-          },
+          sourceContext: sourceContext,
           requirePlanApproval: values.requirePlanApproval,
           automationMode: values.autoCreatePR
             ? AutomationMode.AUTO_CREATE_PR
@@ -143,14 +147,18 @@ export default function Command(props: LaunchProps<{ launchContext?: LaunchConte
           itemProps.sourceId.onChange?.(value);
           const source = sources?.find((s) => s.name === value);
           setSelectedSource(source);
-          if (source?.githubRepo?.defaultBranch?.displayName) {
+          if (value === "NO_REPO") {
+            // Clear or handle no repo specific logic if needed
+            setValue("startingBranch", "");
+          } else if (source?.githubRepo?.defaultBranch?.displayName) {
             setValue("startingBranch", source.githubRepo.defaultBranch.displayName);
           }
         }}
         value={itemProps.sourceId.value}
       />
 
-      <BranchDropdown selectedSource={selectedSource} itemProps={itemProps} />
+      {selectedSource && (<BranchDropdown selectedSource={selectedSource} itemProps={itemProps} />
+      )}
 
       <Form.Separator />
 

--- a/src/list-sessions.tsx
+++ b/src/list-sessions.tsx
@@ -504,7 +504,7 @@ function SessionDetail(props: { session: Session }) {
           <List.Item.Detail.Metadata.Label title="State" text={formatSessionState(session.state)} />
           <List.Item.Detail.Metadata.Separator />
           {prUrl && <List.Item.Detail.Metadata.Link title="Pull Request" text={prUrl} target={prUrl} />}
-          <List.Item.Detail.Metadata.Label title="Repository" text={formatRepoName(session.sourceContext.source)} />
+          <List.Item.Detail.Metadata.Label title="Repository" text={formatRepoName(session.sourceContext?.source)} />
         </List.Item.Detail.Metadata>
       }
     />
@@ -527,7 +527,7 @@ function SessionListItem(props: {
       id={props.session.id}
       key={props.session.id}
       title={title}
-      subtitle={props.isShowingDetail ? undefined : formatRepoName(props.session.sourceContext.source)}
+      subtitle={props.isShowingDetail ? undefined : formatRepoName(props.session.sourceContext?.source)}
       icon={getStatusIconForSession(props.session)}
       accessories={getSessionAccessories(props.session, {
         hideCreateTime: props.isShowingDetail,
@@ -708,7 +708,7 @@ export default function Command() {
   ).sort();
 
   const filteredData = data?.filter((session) => {
-    if (filterRepo !== "all" && formatRepoName(session.sourceContext.source) !== filterRepo) return false;
+    if (filterRepo !== "all" && formatRepoName(session.sourceContext?.source) !== filterRepo) return false;
     return true;
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export interface Session {
   name?: string;
   id: string;
   prompt: string;
-  sourceContext: SourceContext;
+  sourceContext?: SourceContext;
   title?: string;
   requirePlanApproval?: boolean;
   automationMode?: AutomationMode;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -168,7 +168,8 @@ export async function refreshMenuBar(): Promise<void> {
   }
 }
 
-export function formatRepoName(source: string): string {
+export function formatRepoName(source?: string): string {
+  if (!source) return "No Repository";
   if (source.startsWith("sources/github/")) {
     return source.replace("sources/github/", "");
   }


### PR DESCRIPTION
This pull request improves handling of sessions that do not have a repository associated with them ("No Repository"). It introduces a "No Repository" option in the source selection dropdown, updates logic throughout the codebase to handle cases where no repository is selected, and ensures that UI components display appropriate labels and handle missing repository data gracefully.

Repository selection and context handling:

* Added a "No Repository" (`NO_REPO`) option to the `SourceDropdown`, allowing users to create sessions without associating a repository.
* Updated session creation logic to set `sourceContext` to `undefined` when "No Repository" is selected, and to only build the `sourceContext` object when a repository is chosen.
* Modified the logic for handling branch selection: when "No Repository" is chosen, the starting branch is cleared, and the branch dropdown is only shown when a repository is selected.

Type and utility function updates:

* Made the `sourceContext` property in the `Session` type optional, and updated the `formatRepoName` utility to handle undefined sources, returning "No Repository" when appropriate. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL5-R5) [[2]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L171-R172)

UI improvements for sessions without repositories:

* Updated UI components in `list-sessions.tsx` to handle cases where `sourceContext` may be undefined, ensuring that labels and filters display "No Repository" when appropriate and do not throw errors. [[1]](diffhunk://#diff-a486d9e7b951d44dd374662c2483ffe0d6273dfe04c12a7ef75c0d3023c601e4L507-R507) [[2]](diffhunk://#diff-a486d9e7b951d44dd374662c2483ffe0d6273dfe04c12a7ef75c0d3023c601e4L530-R530) [[3]](diffhunk://#diff-a486d9e7b951d44dd374662c2483ffe0d6273dfe04c12a7ef75c0d3023c601e4L711-R711)